### PR TITLE
Update README.md with correct URL for Jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Alpine based image that can be installed on a Docker enabled CI service to build
 * node (v6.9.2)
 * [aerobatic-cli](https://www.aerobatic.com/docs/cli/) (1.0.14)
 
-Available on Dockerhub at https://hub.docker.com/r/aerobatic/hugo/
+Available on Dockerhub at https://hub.docker.com/r/aerobatic/jekyll/


### PR DESCRIPTION
Jekyll URL points to `hugo` Docker image. 

Same error on `https://www.aerobatic.com/blog/optimized-docker-images-continuous-deployment/` blog post!